### PR TITLE
PR:运行工作流时，Inputs允许传递obj类型的参数；Files 打过时标记

### DIFF
--- a/DifyAI.Test/WorkflowsTest.cs
+++ b/DifyAI.Test/WorkflowsTest.cs
@@ -2,14 +2,14 @@ using DifyAI.ObjectModels;
 
 namespace DifyAI.Test;
 
-public class WorkflowsTest: TestBase
+public class WorkflowsTest : TestBase
 {
     [Fact]
     public async Task WorkflowStream_StartAndStop()
     {
         var req = new CompletionRequest
         {
-            Inputs = new Dictionary<string, string>
+            Inputs = new Dictionary<string, object>
             {
                 { "content", "What is the capital of France?" }
             },
@@ -25,7 +25,7 @@ public class WorkflowsTest: TestBase
                     TaskId = start.TaskId,
                 });
             }
-            
+
             Assert.NotNull(rsp.Event);
         }
     }

--- a/DifyAI/DifyAI.csproj
+++ b/DifyAI/DifyAI.csproj
@@ -7,7 +7,7 @@
     <Authors>BitBrewing</Authors>
     <Company>Yiqifei</Company>
     <Description>DifyAI SDK https://dify.ai/</Description>
-    <Version>3.7.3</Version>
+    <Version>3.7.4</Version>
     <PackageProjectUrl>https://github.com/BitBrewing/dify-csharp-sdk</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>dify</PackageTags>

--- a/DifyAI/ObjectModels/CompletionRequest.cs
+++ b/DifyAI/ObjectModels/CompletionRequest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace DifyAI.ObjectModels
@@ -29,6 +30,7 @@ namespace DifyAI.ObjectModels
         /// <summary>
         /// 上传的文件
         /// </summary>
+        [Obsolete("已弃用，请通过 Inputs 参数上传文件。")]
         [JsonPropertyName("files")]
         public IEnumerable<CompletionFile> Files { get; set; }
     }

--- a/DifyAI/ObjectModels/CompletionRequest.cs
+++ b/DifyAI/ObjectModels/CompletionRequest.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
 namespace DifyAI.ObjectModels
 {
@@ -13,7 +9,7 @@ namespace DifyAI.ObjectModels
         /// 允许传入 App 定义的各变量值。 inputs 参数包含了多组键值对（Key/Value pairs），每组的键对应一个特定变量，每组的值则是该变量的具体值。 默认 {}
         /// </summary>
         [JsonPropertyName("inputs")]
-        public Dictionary<string, string> Inputs { get; set; } = new Dictionary<string, string>();
+        public Dictionary<string, object> Inputs { get; set; } = new Dictionary<string, object>();
 
         /// <summary>
         /// <list type="bullet">


### PR DESCRIPTION
目前 Dify 已经将 Files 标记为了 LEGACY，文件目前使用 Inputs 上传，故此请求更新 SDK 。

官方示例：

``` json
{
  "inputs": {
    "{variable_name}": 
    [
      {
      "transfer_method": "local_file",
      "upload_file_id": "{upload_file_id}",
      "type": "{document_type}"
      }
    ]
  }
}
```
