### PR TITLE
[Feature] list all conversation variables

### DIFF
--- a/DifyAI/Interfaces/IConversationsService.cs
+++ b/DifyAI/Interfaces/IConversationsService.cs
@@ -35,5 +35,13 @@ namespace DifyAI.Interfaces
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         Task<ConversationRenameResponse> RenameAsync(ConversationRenameRequest request, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 获取会话变量列表
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<ConversationVariableListResponse> ListVariablesAsync(ConversationVariableListRequest request, CancellationToken cancellationToken = default);
     }
 }

--- a/DifyAI/ObjectModels/ConversationVariable.cs
+++ b/DifyAI/ObjectModels/ConversationVariable.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using DifyAI.Json;
+
+namespace DifyAI.ObjectModels;
+
+public class ConversationVariable
+{
+    /// <summary>
+    /// 變量 ID。
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+
+    /// <summary>
+    /// 變量名称
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+    
+    /// <summary>
+    /// 變量類型
+    /// </summary>
+    [JsonPropertyName("value_type")]
+    public string ValueType { get; set; }
+    
+    /// <summary>
+    /// 變量值
+    /// </summary>
+    [JsonPropertyName("value")]
+    public string Value { get; set; }
+    
+    /// <summary>
+    /// 创建时间。
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    [JsonConverter(typeof(UnixTimestampConverter))]
+    public DateTimeOffset CreatedAt { get; set; }
+    
+    /// <summary>
+    /// 更變时间。
+    /// </summary>
+    [JsonPropertyName("updated_at")]
+    [JsonConverter(typeof(UnixTimestampConverter))]
+    public DateTimeOffset UpdatedAt { get; set; }
+}

--- a/DifyAI/ObjectModels/ConversationVariableListRequest.cs
+++ b/DifyAI/ObjectModels/ConversationVariableListRequest.cs
@@ -1,0 +1,31 @@
+using System.Text.Json.Serialization;
+
+namespace DifyAI.ObjectModels;
+
+public class ConversationVariableListRequest : RequestBase
+{
+    /// <summary>
+    /// 会话ID
+    /// </summary>
+    [JsonIgnore]
+    public string ConversationId { get; set; }
+    
+    /// <summary>
+    /// 用户标识，用于定义终端用户的身份，方便检索、统计。 由开发者定义规则，需保证用户标识在应用内唯一。
+    /// </summary>
+    [JsonIgnore]
+    public string User { get; set; }
+
+    /// <summary>
+    /// 当前页最后面一条记录的 ID，默认 null
+    /// </summary>
+    [JsonPropertyName("last_id")]
+    public string LastId { get; set; }
+
+    /// <summary>
+    /// 一次请求返回多少条聊天记录，默认 20 条。
+    /// </summary>
+    [JsonPropertyName("limit")]
+    public int? Limit { get; set; }
+
+}

--- a/DifyAI/ObjectModels/ConversationVariableListResponse.cs
+++ b/DifyAI/ObjectModels/ConversationVariableListResponse.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace DifyAI.ObjectModels;
+
+public class ConversationVariableListResponse : ResponseBase
+{
+    /// <summary>
+    /// 返回条数，若传入超过系统限制，返回系统限制数量
+    /// </summary>
+    [JsonPropertyName("limit")]
+    public int Limit { get; set; }
+
+    /// <summary>
+    /// 是否存在下一页
+    /// </summary>
+    [JsonPropertyName("has_more")]
+    public bool HasMore { get; set; }
+
+    /// <summary>
+    /// 会话變量列表
+    /// </summary>
+    [JsonPropertyName("data")]
+    public IReadOnlyList<ConversationVariable> Data { get; set; }
+}

--- a/DifyAI/Services/ConversationsService.cs
+++ b/DifyAI/Services/ConversationsService.cs
@@ -25,5 +25,10 @@ namespace DifyAI.Services
         {
             return await _httpClient.PostAsAsync<ConversationRenameResponse>($"conversations/{Uri.EscapeDataString(request.ConversationId)}/name", request, cancellationToken);
         }
+
+        public async Task<ConversationVariableListResponse> ListVariablesAsync(ConversationVariableListRequest request, CancellationToken cancellationToken = default)
+        {
+            return await _httpClient.GetAsAsync<ConversationVariableListResponse>($"conversations/{Uri.EscapeDataString(request.ConversationId)}/variables?user={Uri.EscapeDataString(request.User)}", request, cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
由於dify當中存在value type: string, number, object, array...
請問有考慮引入System.text.json的新enum converter去把value type enum化, 並根據type允許傳入generic type去解value嗎?
https://github.com/dotnet/runtime/issues/74385