### PR TITLE
fiexd: upload failed when file stream is MemoryStream

### DIFF
--- a/DifyAI/Extensions/HttpClientExtensions.cs
+++ b/DifyAI/Extensions/HttpClientExtensions.cs
@@ -312,28 +312,36 @@ namespace DifyAI
             string fileName;
             string mimeType;
             bool shouldDisposeStream = false;
-            
+
             // 优先使用 FileStream，如果没有则使用 File 路径
             if (requestModel.FileStream != null)
             {
                 fileStream = requestModel.FileStream;
-                // 尝试从流中获取文件名，如果是 FileStream 类型
                 if (fileStream is FileStream fs)
                 {
-                    fileName = Path.GetFileName(fs.Name);
-                    mimeType = MimeUtility.GetMimeMapping(fs.Name);
+                    //优先从参数中获取文件名，如果没有则从 FileStream 中获取
+                    if (!string.IsNullOrWhiteSpace(requestModel.FileName)) fileName = requestModel.FileName;
+                    else fileName = Path.GetFileName(fs.Name);
+
+                    mimeType = MimeUtility.GetMimeMapping(fileName);
                 }
                 else
                 {
-                    // 如果不是 FileStream，使用默认文件名
-                    fileName = "document";
+                    // 从参数中获取文件名，如果没有则报错
+                    if (!string.IsNullOrWhiteSpace(requestModel.FileName)) fileName = requestModel.FileName;
+                    else throw new ArgumentException("FileName must be provided");
+
                     mimeType = "application/octet-stream";
                 }
             }
             else if (!string.IsNullOrEmpty(requestModel.File))
             {
                 fileStream = File.OpenRead(requestModel.File);
-                fileName = Path.GetFileName(requestModel.File);
+
+                //优先从参数中获取文件名，如果没有则从 FileStream 中获取
+                if (!string.IsNullOrWhiteSpace(requestModel.FileName)) fileName = requestModel.FileName;
+                else fileName = Path.GetFileName(requestModel.File);
+
                 mimeType = MimeUtility.GetMimeMapping(requestModel.File);
                 shouldDisposeStream = true;
             }

--- a/DifyAI/ObjectModels/AudioToTextRequest.cs
+++ b/DifyAI/ObjectModels/AudioToTextRequest.cs
@@ -19,6 +19,12 @@ namespace DifyAI.ObjectModels
         public Stream FileStream { get; set; }
 
         /// <summary>
+        /// 指定上传的文件名（使用文件流上传，且文件流非FileStream类型时必需指定文件名）
+        /// </summary>
+        [JsonIgnore]
+        public string FileName { get; set; }
+
+        /// <summary>
         /// 用户标识，用于定义终端用户的身份，必须和发送消息接口传入 user 保持一致。
         /// </summary>
         [JsonPropertyName("user")]

--- a/DifyAI/ObjectModels/DocumentUpdateByFileRequest.cs
+++ b/DifyAI/ObjectModels/DocumentUpdateByFileRequest.cs
@@ -30,6 +30,12 @@ namespace DifyAI.ObjectModels
         public Stream FileStream { get; set; }
 
         /// <summary>
+        /// 指定上传的文件名（使用文件流上传，且文件流非FileStream时必需指定文件名）
+        /// </summary>
+        [JsonIgnore]
+        public string FileName { get; set; }
+
+        /// <summary>
         ///     Source document ID (optional)
         ///     Used to re-upload the document or modify the document cleaning and segmentation configuration.The missing information is copied from the source document
         ///     The source document cannot be an archived document

--- a/DifyAI/ObjectModels/DocumentUpsetByFileRequest.cs
+++ b/DifyAI/ObjectModels/DocumentUpsetByFileRequest.cs
@@ -25,6 +25,12 @@ namespace DifyAI.ObjectModels
         public Stream FileStream { get; set; }
 
         /// <summary>
+        /// 指定上传的文件名（使用文件流上传，且文件流非FileStream时必需指定文件名）
+        /// </summary>
+        [JsonIgnore]
+        public string FileName { get; set; }
+
+        /// <summary>
         ///     Source document ID (optional)
         ///     Used to re-upload the document or modify the document cleaning and segmentation configuration.The missing information is copied from the source document
         ///     The source document cannot be an archived document

--- a/DifyAI/ObjectModels/FileUploadRequest.cs
+++ b/DifyAI/ObjectModels/FileUploadRequest.cs
@@ -22,6 +22,12 @@ namespace DifyAI.ObjectModels
         public Stream FileStream { get; set; }
 
         /// <summary>
+        /// 指定上传的文件名（使用文件流上传，且文件流非FileStream类型时必需指定文件名）
+        /// </summary>
+        [JsonIgnore]
+        public string FileName { get; set; }
+
+        /// <summary>
         /// 用户标识，用于定义终端用户的身份，必须和发送消息接口传入 user 保持一致。
         /// </summary>
         [JsonPropertyName("user")]

--- a/DifyAI/ObjectModels/IUploadRequest.cs
+++ b/DifyAI/ObjectModels/IUploadRequest.cs
@@ -19,5 +19,10 @@ namespace DifyAI.ObjectModels
         /// 要上传的文件流(与 File 选其一)
         /// </summary>
         Stream FileStream { get; }
+
+        /// <summary>
+        /// 要上传的文件名（使用文件流上传，且文件流非FileStream类型时必需指定文件名）
+        /// </summary>
+        string FileName { get; }
     }
 }


### PR DESCRIPTION
fixed: #43 
Add a property called `FileName` to interface `IUploadRequest` so that the file name can be specified when uploading.